### PR TITLE
Updates the app script and website for the correct terminology

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -36,7 +36,7 @@ do
 
 		mkdir -p $DATADIR
 		cd $DATADIR
-		mkdir -p tx addr general bids mastercoin_verify/addresses mastercoin_verify/transactions www
+		mkdir -p tx addr general offers mastercoin_verify/addresses mastercoin_verify/transactions www
 
 		# parse until full success
 		x=1 # assume failure
@@ -52,12 +52,12 @@ do
 		# update archive
 		python $TOOLSDIR/msc_archive.py -r $TOOLSDIR 2>&1 > $ARCHIVE_LOG
 	
-		mkdir -p $DATADIR/www/tx $DATADIR/www/addr $DATADIR/www/general $DATADIR/www/bids $DATADIR/www/mastercoin_verify/addresses $DATADIR/www/mastercoin_verify/transactions
+		mkdir -p $DATADIR/www/tx $DATADIR/www/addr $DATADIR/www/general $DATADIR/www/offers $DATADIR/www/mastercoin_verify/addresses $DATADIR/www/mastercoin_verify/transactions
 
         cp --no-clobber $DATADIR/tx/* $DATADIR/www/tx
 		cp --no-clobber $DATADIR/addr/* $DATADIR/www/addr
 		cp $DATADIR/general/* $DATADIR/www/general
-		cp --no-clobber $DATADIR/bids/* $DATADIR/www/bids
+		cp --no-clobber $DATADIR/offers/* $DATADIR/www/offers
 		cp --no-clobber $DATADIR/mastercoin_verify/addresses/* $DATADIR/www/mastercoin_verify/addresses
 		cp --no-clobber $DATADIR/mastercoin_verify/transactions/* $DATADIR/www/mastercoin_verify/transactions
 	

--- a/etc/nginx/sites-available/default
+++ b/etc/nginx/sites-available/default
@@ -44,8 +44,8 @@ server {
 		alias /tmp/msc-webwallet/www/revision.json;
 	}
 
-	location ~ "^/bids/(.*)$" {
-		alias /tmp/msc-webwallet/www/bids/$1;
+	location ~ "^/offers/(.*)$" {
+		alias /tmp/msc-webwallet/www/offers/$1;
 	}
 
 	location ~ "^/general/(.*)$" {

--- a/www/selloffer.html
+++ b/www/selloffer.html
@@ -173,7 +173,7 @@
                             <div class="clearfix"></div>
                             <div class="col-md-12">
                                 <table class="table table-striped table-hover table-condensed">
-                                    <caption>Bids on this offer</caption>
+                                    <caption>offers on this offer</caption>
                                    <thead>
                                         <tr>
                                             <th>Transaction</th>
@@ -183,38 +183,38 @@
                                         </tr>
                                    </thead>
                                     <tbody>
-                                        <tr ng-repeat="bid in bids">
-                                            <td ng-switch on="bid.icon">
-                                            	<img class="round-corner {{bid.color}} iconPopupInit"
-													src="ico/{{bid.icon}}24t.png"
+                                        <tr ng-repeat="offer in offers">
+                                            <td ng-switch on="offer.icon">
+                                            	<img class="round-corner {{offer.color}} iconPopupInit"
+													src="ico/{{offer.icon}}24t.png"
 													ng-init="createIconPopup()"
-													data-content="{{bid.icon_text}}" rel="popover"
+													data-content="{{offer.icon_text}}" rel="popover"
 													data-placement="bottom"
 													alt="" />
                                                 <span ng-switch-when="selloffer">
-                                                    <a ng-href='selloffer.html?tx={{bid.tx_hash}}&currency={{currency}}'>{{bid.tx_hash | characters:10}}
+                                                    <a ng-href='selloffer.html?tx={{offer.tx_hash}}&currency={{currency}}'>{{offer.tx_hash | characters:10}}
                                                     </a>
                                                 </span>
                                                 <span ng-switch-when="sellaccept">
-                                                    <a ng-href='sellaccept.html?tx={{bid.tx_hash}}&currency={{currency}}'>{{bid.tx_hash | characters:10}}
+                                                    <a ng-href='sellaccept.html?tx={{offer.tx_hash}}&currency={{currency}}'>{{offer.tx_hash | characters:10}}
                                                     </a>
                                                 </span>
                                                 <span ng-switch-when="unknown">
-                                                    <a ng-href='btcpayment.html?tx={{bid.tx_hash}}&currency={{currency}}'>{{bid.tx_hash | characters:10}}
+                                                    <a ng-href='btcpayment.html?tx={{offer.tx_hash}}&currency={{currency}}'>{{offer.tx_hash | characters:10}}
                                                     </a>
                                                 </span>
                                                 <span ng-switch-when="simplesend">
-                                                    <a ng-href='transaction.html?tx={{bid.tx_hash}}&currency={{currency}}'>{{bid.tx_hash | characters:10}}
+                                                    <a ng-href='transaction.html?tx={{offer.tx_hash}}&currency={{currency}}'>{{offer.tx_hash | characters:10}}
                                                     </a>
                                                 </span>
-                                                <span ng-switch-default>{{bid.tx_hash | characters:10}}
+                                                <span ng-switch-default>{{offer.tx_hash | characters:10}}
                                                 </span>
                                             </td>
 
 
-                                            <td>{{bid.formatted_amount}}</td>
-                                            <td>{{bid.status}}</td>
-                                            <td>{{bid.tx_time | date:'yyyy-MM-dd HH:mm:ss UTC'}}</td>
+                                            <td>{{offer.formatted_amount}}</td>
+                                            <td>{{offer.status}}</td>
+                                            <td>{{offer.tx_time | date:'yyyy-MM-dd HH:mm:ss UTC'}}</td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/www/selloffer.js
+++ b/www/selloffer.js
@@ -1,6 +1,6 @@
 function SellofferController($scope, $http) {
     $scope.transactionInformation;
-    $scope.bids;
+    $scope.offers;
 
     $scope.footer = "FOOTER";
     $scope.title = "TITLE";
@@ -20,13 +20,13 @@ function SellofferController($scope, $http) {
             $scope.transactionInformation = data[0];
         });
 
-        var bidsURL = "bids/bids-";
-        bidsURL += myURLParams['tx'];
-        bidsURL += ".json";
+        var offersURL = "offers/offers-";
+        offersURL += myURLParams['tx'];
+        offersURL += ".json";
 
-          $.get(bidsURL, {}).success(function (data) {
+          $.get(offersURL, {}).success(function (data) {
               //data = $.parseJSON(data);
-              $scope.bids = data;
+              $scope.offers = data;
               $scope.$apply();
           });
       


### PR DESCRIPTION
This updates the app to name the sell offer data files by there correct terminology. Previously they used the term "bid" which represents the other side (buy offers). It's a easily overlooked thing but I think it's important to fix this now. 

I have tested this in conjunction with the change to mastercoin-tools (https://github.com/curtislacy/mastercoin-tools/pull/1) and verified the site's functionality is unchanged.

Note: this does not fix the current issue on the sell offer page (http://blockchain-1.labs.engine.co/selloffer.html?tx=e3b77fa025afdd263d414cf8ed4f8e22471c244edfa0d70acdaa1e88f9640936&currency=TMSC) 
which I did not even notice until I started testing this change. I can look into this next.

The complete steps for integrating this change should be:
- Pull new mastercoin-tools into node_modules once PR1 is merged
- copy etc/nginx/sites-available/default to /etc/nginx/sites-available/default
- restart nginx
- restart app.sh (it will take some time as msc_validate.py writes the new files)
- remove bids/\* and bids/\* if you want
