### PR TITLE
Fix sell form to use fixed BTC/MSC rate

### DIFF
--- a/api/sell.py
+++ b/api/sell.py
@@ -28,8 +28,8 @@ def sell_form_response(response_dict):
     amount=response_dict['amount'][0]
     if float(amount)<0 or float( from_satoshi( amount ))>max_currency_value:
         return (None, 'Invalid amount')
-    price=response_dict['price'][0]
-    if float(price)<0 or float( from_satoshi( price ))>max_currency_value:
+    price=float(response_dict['price'][0])
+    if price < 0:
         return (None, 'Invalid price')
     min_buyer_fee=response_dict['min_buyer_fee'][0]
     if float(min_buyer_fee)<0 or float( from_satoshi( min_buyer_fee ))>max_currency_value:
@@ -49,8 +49,8 @@ def sell_form_response(response_dict):
         else:
             return (None, 'Invalid currency')
 
-    satoshi_price=int( price )
-    bitcoin_amount_desired=int( satoshi_price * int(amount) )
+    #satoshi_price=int( price )
+    bitcoin_amount_desired=int( price * int(amount) )
 
     #DEBUG info(['early days', seller, amount, satoshi_price, bitcoin_amount_desired, min_buyer_fee, fee, blocks, currency])
     if pubkey != None:

--- a/www/js/WalletTradeAssetsController.js
+++ b/www/js/WalletTradeAssetsController.js
@@ -33,6 +33,7 @@ function WalletTradeAssetsController($modal, $scope, $http, $q, userService) {
 
   // [ Retrieve Balances ]
   $scope.currencyUnit = 'stom' // satoshi to millibitt
+  $scope.amountUnit = 'mtow'
   $scope.balanceData = [ 0 ];
   var addrListBal = [];
 
@@ -445,12 +446,13 @@ function WalletTradeAssetsController($modal, $scope, $http, $q, userService) {
     var minerMinimum = 10000; 
     var nonZeroValue = 1; 
 
-    var salePricePerCoin = Math.ceil( formatCurrencyInFundamentalUnit( +$scope.salePricePerCoin , currencyUnit[3]+'tos'  ) );
+    // var salePricePerCoin = Math.ceil( formatCurrencyInFundamentalUnit( +$scope.salePricePerCoin , currencyUnit[3]+'tos'  ) );
+    var salePricePerCoin = +$scope.salePricePerCoin
     var buyersFee = Math.ceil( formatCurrencyInFundamentalUnit( +$scope.buyersFee , currencyUnit[3] +'tos' ) );
     var minerFees = Math.ceil( formatCurrencyInFundamentalUnit( +$scope.minerFees , currencyUnit[3] +'tos' ) );
     var saleAmount = Math.ceil( formatCurrencyInFundamentalUnit( +$scope.saleAmount , currencyUnit[3]+'tos'  ) );
 
-    var salePricePerCoinMillis = formatCurrencyInFundamentalUnit( salePricePerCoin , 'stom' ) ;
+    // var salePricePerCoinMillis = formatCurrencyInFundamentalUnit( salePricePerCoin , 'stom' ) ;
     var buyersFeeMillis = formatCurrencyInFundamentalUnit( buyersFee , 'stom'  ) ;
     var minerFeesMillis = formatCurrencyInFundamentalUnit( minerFees , 'stom' ) ;
     var saleAmountMillis = formatCurrencyInFundamentalUnit( saleAmount , 'stom'  ) ;
@@ -495,7 +497,7 @@ function WalletTradeAssetsController($modal, $scope, $http, $q, userService) {
           <div class="modal-body">\
               <h3 class="text-center"> Confirm sale order </h3>\
               <h3>You\'re about to put ' + saleAmountMillis + 'm' + $scope.selectedCoin  +  
-              ' on sale at a price of ' +  salePricePerCoinMillis + 'mBTC per coin' +
+              ' on sale at a price of ' +  salePricePerCoin + ' BTC per ' + $scope.selectedCoin +
               ', plus charge ' + buyersFeeMillis  + ' in fees over ' +
               $scope.saleBlocks + ' blocks.</h3>\
             <p><br>\

--- a/www/js/filter.js
+++ b/www/js/filter.js
@@ -17,7 +17,10 @@ var conversionFactor = {
   //These are original values and are not consistent
   'BTC':  100000,
   'MSC':  100000000,
-  'TMSC': 100000000
+  'TMSC': 100000000,
+
+  'mtow': 1000,
+  'wtow': 1
 };
 function getConversionFactor( symbol ) {
   return conversionFactor[ symbol ];

--- a/www/partials/wallet_sale.html
+++ b/www/partials/wallet_sale.html
@@ -30,9 +30,9 @@
     <div class="col-xs-6"> 
       <br><br><br><br><br><br><br><br><br>
       <button class="btn btn-primary btn-md" 
-      ng-click="currencyUnit = 'stom'" type="button">Convert to mBTC </button>
+      ng-click="currencyUnit = 'stom'; amountUnit = 'mtow'" type="button">Convert to mBTC </button>
       <button class="btn btn-primary btn-md" 
-      ng-click="currencyUnit = 'stow'" type="button">Convert to whole BTC </button>
+      ng-click="currencyUnit = 'stow'; amountUnit = 'wtow'" type="button">Convert to whole BTC </button>
     </div>
   </div>
   <div class="row">
@@ -48,9 +48,12 @@
       </div>
       <br>
       <div class="input-group">
-        <span class="input-group-addon"> Price per coin (in {{currencyUnit[currencyUnit.length-1]}}BTC): </span>
+        <span class="input-group-addon"> Price per coin (in BTC/{{ selectedCoin }}): </span>
         <input name="ppc" type="number" ng-model="salePricePerCoin" class="form-control" 
           placeholder="{{{ balance: 1000000, symbol: currencyUnit} | cryptocurrency}}" required>
+        <span class="input-group-addon" > 
+          Total Sale Amount: {{ ({ balance: (saleAmount || 0), symbol: amountUnit } | cryptocurrency)*(salePricePerCoin || 0)}}
+          BTC</span>
       </div>
       <br>
       <div id="time-blocks" class="input-group">


### PR DESCRIPTION
This fixes the incorrect handling of the exchange rate in placing a sell order. I noticed this when I tried to sell with a fixed rate of 0.15 BTC/MSC and got this:
https://masterchest.info/lookuptx.aspx?txid=b944f404b23e94cae961df161462305997d3fbb50ce67f3ad0b45a562531311b

Modified the form to use the fix rated of BTC/MSC (not messing with units such as millibits) which is how it should be handled. Also allows for easy comparison to centralized exchanges such as masterxchange.

Testing:
https://masterchest.info/lookuptx.aspx?txid=5560e74631e2eb6f38a3b17b46c0265d213cc8bd4ffc4397d4b4a1e8702985f5
