### PR TITLE
Added the ``Access-Control-Allow-Origin: *`` header to some endpoints th...

### DIFF
--- a/etc/nginx/sites-available/default
+++ b/etc/nginx/sites-available/default
@@ -62,10 +62,12 @@ server {
 	}
 
   location ~ "^/v1/property/([0-9]*.json)$" {
+	add_header Access-Control-Allow-Origin *;
     alias /var/lib/omniwallet/www/properties/properties-$1;
   }
   
   location ~ "^/v1/values/(.*)$" {
+	add_header Access-Control-Allow-Origin *;
     alias /var/lib/omniwallet/www/values/$1;
   }
   location ~ "^/v1/values/history/(.*)$" {
@@ -87,6 +89,7 @@ server {
 
 	set $PORT 1088;
     location /v1/address/addr/ {
+	add_header Access-Control-Allow-Origin *;
         set   $app   get_balance;
         uwsgi_pass   127.0.0.1:$PORT;
     }


### PR DESCRIPTION
...at pass public data anyhow, so that people making tools in a browser can just pull the data directly.

The W3C guidance seems to be that if the resource is publicly available anyhow, it's safe to set.

Looking at this: https://www.owasp.org/index.php?title=HTML5_Security_Cheat_Sheet&setlang=es#Content_Security_Policy
The "Cross Origin Resource Sharing" section - Specifically: "Ensure that URLs responding with Access-Control-Allow-Origin: \* do not include any sensitive content or information that might aid attacker in further attacks. Use the Access-Control-Allow-Origin header only on chosen URLs that need to be accessed cross-domain. Don't use the header for the whole domain."

Since the transactions on the blockchain and the balances are public anyhow, adding the "Access-Control-Allow-Origin: *" header to the API endpoints that READ blockchain data should be safe.  Things that access the wallet files, or submit transactions, maybe not.  But things that just read balances or property definitions should be safe.
