### PR TITLE
Add needed description to Delete address button

### DIFF
--- a/www/partials/wallet_address_list.html
+++ b/www/partials/wallet_address_list.html
@@ -52,7 +52,7 @@
             <td ng-if="currency.property_type == undefined" class="currency">{{ { balance: item.balance, symbol: currency.symbol } | cryptocurrency }} {{currency.name == "Bitcoin" ? "m" : ""}}{{ currency.symbol }}</td>
             <td class="currency">{{item.value | currency}}</td>
             <td>
-                  <button class="btn btn-default" ng-click="openDeleteConfirmForm( item.address )">X</button>
+                  <button class="btn btn-default" ng-click="openDeleteConfirmForm( item.address )" title="Remove address/private key from wallet (previous confirmation)">X</button>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Added a needed description to delete address/private key button that only shows an X and doesn't make clear that previous confirmation is needed to remove it from the wallet.
