### PR TITLE
Send.py shouldn't die on error

### DIFF
--- a/api/send.py
+++ b/api/send.py
@@ -81,15 +81,17 @@ def send_form_response(response_dict):
                     pubkey=from_pubkey
                     response_status='OK'
 
-    if pubkey != None:
-        tx_to_sign_dict=prepare_send_tx_for_signing( pubkey, to_addr, marker_addr, currency_id, amount, btc_fee)
-    else:
-        # hack to show error on page
-        tx_to_sign_dict['sourceScript']=response_status
+    try:
+      if pubkey != None:
+          tx_to_sign_dict=prepare_send_tx_for_signing( pubkey, to_addr, marker_addr, currency_id, amount, btc_fee)
+      else:
+          # hack to show error on page
+          tx_to_sign_dict['sourceScript']=response_status
 
-    response='{"status":"'+response_status+'", "transaction":"'+tx_to_sign_dict['transaction']+'", "sourceScript":"'+tx_to_sign_dict['sourceScript']+'"}'
-
-    return (response, None)
+      response='{"status":"'+response_status+'", "transaction":"'+tx_to_sign_dict['transaction']+'", "sourceScript":"'+tx_to_sign_dict['sourceScript']+'"}'
+      return (response, None)
+    except Exception as e:
+      return (None, str(e))
 
 
 # simple send and bitcoin send (with or without marker)
@@ -134,13 +136,13 @@ def prepare_send_tx_for_signing(from_address, to_address, marker_address, curren
     inputs_total_value=0
 
     if inputs_number < 1:
-        error('zero inputs')
+        raise Exception('Error preparing transaction: zero inputs')
     for i in range(inputs_number):
         inputs.append(utxo_split[i*12+3])
         try:
             inputs_total_value += int(utxo_split[i*12+7])
         except ValueError:
-            error('error parsing value from '+utxo_split[i*12+7])
+            raise Exception('Error preparing transaction: parsing value from '+utxo_split[i*12+7])
 
     inputs_outputs='/dev/stdout'
     for i in inputs:
@@ -149,7 +151,7 @@ def prepare_send_tx_for_signing(from_address, to_address, marker_address, curren
     # calculate change
     change_value=inputs_total_value-required_value-fee
     if change_value < 0:
-        error ('negative change value')
+        raise Exception('Error preparing transaction: negative change value')
 
     if currency_id == 0: # bitcoin
         # create a normal bitcoin transaction (not mastercoin)


### PR DESCRIPTION
replace the process killing error call with returning an error message to the user.

This will prevent send.py from intentionally killing uwsgi as well as returning the error message to the user 
