### PR TITLE
Overview: Updated Graph and Asset names

### DIFF
--- a/www/js/AssetTypesController.js
+++ b/www/js/AssetTypesController.js
@@ -71,6 +71,7 @@ angular.module('omniwallet')
                       if (result.status == 200)
                         this.property_type = result.data[0].formatted_property_type;
                       this.name = result.data[0].propertyName + ' (' + this.symbol.match(/^SP([0-9]+)$/)[1] + ')';
+		      this.shortname = result.data[0].propertyName;
                     };
                     spReqs.push($http.get('/v1/property/' + spMatch[1] + '.json').then(updateFunction.bind(balances[b])));
                   }
@@ -134,12 +135,6 @@ angular.module('omniwallet')
   $rootScope.$on('APPRAISER_VALUE_CHANGED', function() {
     $scope.refresh();
   });
-
-  $scope.refreshInit = function() {
-    var appraiser = $injector.get('appraiser');
-    $scope.refresh();
-    appraiser.updateValues(function() { console.log("refreshed init") });
-  }
 
   $scope.refresh = function() {
 

--- a/www/js/service.js
+++ b/www/js/service.js
@@ -266,7 +266,9 @@ angular.module('omniwallet').factory('userService', ['$rootScope', '$http', '$in
               addCurrencies(i + 1);
             });
           } else {
-            console.log("Updated Currencies");
+	    $injector.get('appraiser').updateValues(function() {
+                console.log("Updated Currencies");
+            });
           }
         };
         addCurrencies(0);

--- a/www/partials/asset_types.html
+++ b/www/partials/asset_types.html
@@ -18,7 +18,7 @@
           <row class="col-xs-12" ng-click="openCurrencyDetail( currency.symbol )">
             <div class="container-fluid">
               <div class="asset-item col-xs-4 text-left">
-                <span tooltip={{currency.symbol}}>{{currency.name ? currency.name : currency.symbol}}</span>
+                <span tooltip={{currency.symbol}}>{{currency.shortname ? currency.shortname : (currency.name ? currency.name : currency.symbol) }}</span>
               </div>
               <div class="asset-item col-xs-5 text-right">
                 <span ng-if="currency.property_type != undefined && currency.property_type == 1" class="currency">{{ currency.balance }} </span>

--- a/www/partials/wallet_overview.html
+++ b/www/partials/wallet_overview.html
@@ -21,7 +21,7 @@
 
     <h3  ng-init="isLoading=true" ng-show="isLoading" class="text-center">Updating Overview...<img src="/assets/img/34-1.gif"></h3>
     <div ng-hide="isLoading"><br /><br /><br /></div>   
-    <div ng-init="refreshInit()" show-asset-types template="{{template}}">
+    <div ng-init="refresh()" show-asset-types template="{{template}}">
 
 
     </div>


### PR DESCRIPTION
Update overview so the graph and values display immediately once the wallet loads (#482)
Update overview page names to put SP currency identifier only in the tool top.
