### PR TITLE
GA: reorder anonymizeIp, forceSSL, send pageview

### DIFF
--- a/www/footer.html
+++ b/www/footer.html
@@ -33,9 +33,7 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-53639435-1', 'auto');
-  ga('send', 'pageview');
   ga('set', 'anonymizeIp', true);
   ga('set', 'forceSSL', true);
-
-
+  ga('send', 'pageview');
 </script>


### PR DESCRIPTION
SSL should be enforced and IP anonymized before sending back to Google, otherwise the first send might not be secured and anonymized.
