### PR TITLE
add api autoreload process

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -42,6 +42,7 @@ do
         DEBUGLEVEL=`cat $DATADIR/debug.level`
     else
         DEBUGLEVEL=0
+    fi
     export DEBUGLEVEL
 
     ps cax | grep uwsgi > /dev/null


### PR DESCRIPTION
This update adds a watch function to the omni app.   on start we get a sha1sum of the api directory.  Every cycle we compare the original sha to the current sha,  if they do not match we soft reload the api to merge in / get the newest api changes into the code.
