### PR TITLE
Add SMTPSTARTTLS config setting defaulted to False

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5,6 +5,7 @@ SMTPUSER = None   #If your smtp server requires authentication define it here
 SMTPPASS = None   #If your smtp server requires authentication define it here
 SMTPDOMAIN = 'localhost'  #smtp server to use for sending, default    'localhost'
 SMTPPORT = 25     #smtp port,  default 25
+SMTPSTARTTLS = False  # Use starttls before SMTP login
 
 #For wallets and session store you can switch between disk and the database
 LOCALDEVBYPASSDB = 0    #Set to 1 to use local storage/file system, Set to 0 to use database

--- a/api/user_service.py
+++ b/api/user_service.py
@@ -405,6 +405,8 @@ def welcome_email(user_email, wallet, uuid):
     #msg.attach(wfile)
     smtp = smtplib.SMTP(config.SMTPDOMAIN, config.SMTPPORT)
     if config.SMTPUSER is not None and config.SMTPPASS is not None:
+      if config.SMTPSTARTTLS:
+        smtp.starttls()
       smtp.login(config.SMTPUSER, config.SMTPPASS)
     smtp.sendmail(email_from, user_email, msg.as_string())
     smtp.close()


### PR DESCRIPTION
Call smtp.starttls() before smtp.login() when SMTPSTARTTLS is True.

This has been tested to work correctly with Amazon Simple Email Service (SES)
