### PR TITLE
Bugfix: Fix tx creation bug when prev utxo included a non standard output

### DIFF
--- a/api/tx_generate_service.py
+++ b/api/tx_generate_service.py
@@ -540,7 +540,7 @@ def build_transaction(miner_fee_satoshis, pubkey,final_packets, total_packets, t
         prev_tx = conn.getrawtransaction(unspent[0])
 
         for output in prev_tx.vout:
-            if output['scriptPubKey']['reqSigs'] == 1 and output['scriptPubKey']['type'] != 'multisig':
+            if 'reqSigs' in output['scriptPubKey'] and output['scriptPubKey']['reqSigs'] == 1 and output['scriptPubKey']['type'] != 'multisig':
                 for address in output['scriptPubKey']['addresses']:
                     if address == from_address and int(output['n']) == int(unspent[1]):
                         validnextinputs.append({ "txid": prev_tx.txid, "vout": output['n']})

--- a/api/txtools.py
+++ b/api/txtools.py
@@ -367,7 +367,7 @@ def build_transaction(miner_fee_satoshis, pubkey,final_packets, total_packets, t
         prev_tx = getrawtransaction(unspent[0])
 
         for output in prev_tx.vout:
-            if output['scriptPubKey']['reqSigs'] == 1 and output['scriptPubKey']['type'] != 'multisig':
+            if 'reqSigs' in output['scriptPubKey'] and output['scriptPubKey']['reqSigs'] == 1 and output['scriptPubKey']['type'] != 'multisig':
                 for address in output['scriptPubKey']['addresses']:
                     if address == from_address and int(output['n']) == int(unspent[1]):
                         validnextinputs.append({ "txid": prev_tx.txid, "vout": output['n']})

--- a/startPythonApiShell.sh
+++ b/startPythonApiShell.sh
@@ -1,0 +1,7 @@
+DATADIR="/var/lib/omniwallet"
+APPDIR=`pwd`
+TOOLSDIR=$APPDIR/node_modules/mastercoin-tools
+export TOOLSDIR
+export DATADIR
+cd $APPDIR/api
+python


### PR DESCRIPTION
Should address the remaining issue causing #1242 

Some non standard transactions 
https://live.blockcypher.com/btc/tx/5d421e3c41b802ebbd66ae77c531e98e218123d808b41011d678be5a8de789ef/

Have nonstandard/null outputs. 
When trying to get utxo info to create the list of spendable inputs the tx creation module was sticking / failing to account for these types of outputs. 
Added check to skip over them properly and confirmed manually tx_creation was able to proceed. 