### PR TITLE
Rebrand v2 - Additional Cleanup

### DIFF
--- a/www/js/controllers/landing/SiteController.js
+++ b/www/js/controllers/landing/SiteController.js
@@ -11,6 +11,8 @@
 
       $http.get('/v1/system/commits', {}).success(function(data) {
         $scope.version = data.commits[0].commitshort;
+      }).error(function(){
+        $scope.version = "Info: Click";
       });
 
       $scope.events = [];

--- a/www/js/controllers/wallet/HistoryController.js
+++ b/www/js/controllers/wallet/HistoryController.js
@@ -2,19 +2,38 @@ angular.module('omniControllers')
 	.controller('WalletHistoryController', ["$scope", "$location", "$http", "hashExplorer", "$translate",
 		function WalletHistoryController($scope, $location, $http, hashExplorer, $translate) {
   			$scope.showtesteco = $scope.account.getSetting('showtesteco');
-  			$scope.history = $scope.wallet.transactions($scope.showtesteco);		
+			$scope.history=[]
+			$scope.wallet.transactions($scope.showtesteco).forEach(function(adrtx){
+				adrtx.then(function(txs){
+					//console.log(txs);
+					txs.forEach(function(tx){
+						$scope.history.push(tx);
+					});
+				});
+			});
 
 
 		    $scope.changeAddress=function(address){
 			  	if(address){
-			  		$scope.selectedAddress = address;
-			  		$scope.history = address.transactions.filter(function(tx){
-				        return ((tx.currency.propertyid < 2147483648 && tx.currency.propertyid != 2) || $scope.showtesteco === 'true'); 
+					//address=address.updateTransactions();
+					$scope.selectedAddress = address;
+					$scope.history = [];
+					address.transactions($scope.showtesteco).then(function(txs){
+						txs.forEach(function(tx){
+							$scope.history.push(tx);
+						});
 				    });
 			  	} else {
 			  		$scope.selectedAddress = undefined;
-			  		$scope.history = $scope.wallet.transactions($scope.showtesteco);
-			  	
+					$scope.history=[]
+					$scope.wallet.transactions($scope.showtesteco).forEach(function(adrtx){
+						adrtx.then(function(txs){
+							//console.log(txs);
+							txs.forEach(function(tx){
+								$scope.history.push(tx);
+							});
+						});
+					});			  	
 			  	}
 		    }
 

--- a/www/js/factories/AddressModelFactory.js
+++ b/www/js/factories/AddressModelFactory.js
@@ -12,14 +12,13 @@ angular.module("omniFactories")
 					self.privkey = privkey;
 					self.pubkey = pubkey;
 					self.balance = [];
-					self.transactions = [];
+					//self.transactions = [];
 					self.qr = "https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl="+hash+"&choe=UTF-8";
 					
-					AddressManager.getTransactions(hash).then(function(result){
-						var data = result.data;
-
-						self.transactions = data.transactions;
-					})
+					//AddressManager.getTransactions(hash).then(function(result){
+					//	var data = result.data;
+					//	self.transactions = data.transactions;
+					//})
 
 					BalanceSocket.on("address:"+hash, function(data){
 						if(self.balance != data.balance){
@@ -50,13 +49,28 @@ angular.module("omniFactories")
 					BalanceSocket.emit("address:add", {data:hash});
 				}
 
+				self.transactions = function(showtesteco){
+					address=self.hash;
+					//console.log("Starting "+address);
+					return AddressManager.getTransactions(address).then(function(result){
+						var data = result.data;
+						//console.log("found data for "+data.address+" its length is "+data.transactions.length);
+						txs=data.transactions;
+						return txs.map(function(tx){
+							if ((tx.currency.propertyid < 2147483648 && tx.currency.propertyid != 2) || showtesteco === 'true') {
+								return tx;
+							}
+						});
+					});
+				}
+
 				self.getDisplayBalance = function(assetId){
 					var currencyItem = self.balance.filter(function(asset){
 						return asset.id == assetId;
 					})[0];
 
 					if(currencyItem.divisible)
-	                    var value=new Big(currencyItem.value).times(WHOLE_UNIT).valueOf();
+						var value=new Big(currencyItem.value).times(WHOLE_UNIT).valueOf();
 					
 					return value || currencyItem.value;
 				}
@@ -67,7 +81,7 @@ angular.module("omniFactories")
 					})[0];
 
 					if(currencyItem.divisible)
-	                    var value=new Big(currencyItem.pendingneg).times(WHOLE_UNIT).valueOf();
+						var value=new Big(currencyItem.pendingneg).times(WHOLE_UNIT).valueOf();
 					
 					return value || currencyItem.pendingneg;
 				}
@@ -78,7 +92,7 @@ angular.module("omniFactories")
 					})[0];
 					
 					if(currencyItem && currencyItem.divisible)
-	                    var value=new Big(currencyItem.pendingpos).times(WHOLE_UNIT).valueOf();
+						var value=new Big(currencyItem.pendingpos).times(WHOLE_UNIT).valueOf();
 					
 					return value || currencyItem.pendingpos;
 				}

--- a/www/js/services/AddressManagerService.js
+++ b/www/js/services/AddressManagerService.js
@@ -39,7 +39,10 @@ angular.module("omniServices")
 			var data = {
 			  addr: address
 			};
-			var promise = $http.post(url, data);
-			return promise;
+			//var promise = $http.post(url, data);
+			//return promise;
+			return $http.post(url, data).then(function(response) {
+				return response;
+			});
 	    }
 	}]);

--- a/www/js/services/WalletService.js
+++ b/www/js/services/WalletService.js
@@ -152,13 +152,9 @@ angular.module("omniServices")
 	        }
 
 	        self.transactions = function(showtesteco){
-	        	return self.addresses.map(function(address){
-	        		return address.transactions;
-	        	}).reduce(function(previous,current){
-	        		return previous.concat(current);
-	        	}).filter(function(tx){
-			        return ((tx.currency.propertyid < 2147483648 && tx.currency.propertyid != 2) || showtesteco === 'true'); 
-			    });
+			return self.addresses.map(function(address){
+        			return address.transactions(showtesteco);
+			});
 	        }
 
 	        self.tradableAddresses = function(){

--- a/www/locales/ar.json
+++ b/www/locales/ar.json
@@ -71,7 +71,7 @@
                         },
                         "TOKEN":{
                                 "TITLE":"Omnis",
-                                "FIRST" : "Omnis (symbol OMNI) are digital tokens that are necessary for the use of some features of the Omni Protocol. The total number of Omnis in existence is 619,478.6 and no more MSC will ever be created. Additionally, Omnis can not be mined into existence. The 619,478.6 OMNI were generated as a result of a public fundraiser in the style of Kickstarter.com.",
+                                "FIRST" : "Omnis (symbol OMNI) are digital tokens that are necessary for the use of some features of the Omni Protocol. The total number of Omnis in existence is 619,478.6 and no more MSC will ever be created. Additionally, Omnis can not be mined into existence. The 619,478.6 OMNI were generated as a result of a public fundraiser in the style of Kickstarter.com."
                         },
                         "INFO":"Information from the ",
                         "EDUCATION":"Master Protocol Education"

--- a/www/locales/en.json
+++ b/www/locales/en.json
@@ -71,7 +71,7 @@
 			},
 			"TOKEN":{
 				"TITLE":"Omnis",
-				"FIRST" : "Omnis (symbol OMNI) are digital tokens that are necessary for the use of some features of the Omni Protocol. The total number of Omnis in existence is 619,478.6 and no more OMNI will ever be created. Additionally, Omnis can not be mined into existence. The 619,478.6 OMNI were generated as a result of a public fundraiser in the style of Kickstarter.com.",
+				"FIRST" : "Omnis (symbol OMNI) are digital tokens that are necessary for the use of some features of the Omni Protocol. The total number of Omnis in existence is 619,478.6 and no more OMNI will ever be created. Additionally, Omnis can not be mined into existence. The 619,478.6 OMNI were generated as a result of a public fundraiser in the style of Kickstarter.com."
 			},
 			"INFO":"Information from the ",
 			"EDUCATION":"Omni Protocol Education"

--- a/www/locales/zh.json
+++ b/www/locales/zh.json
@@ -71,7 +71,7 @@
                         },
                         "TOKEN":{
                                 "TITLE":"Omnis",
-                                "FIRST" : "Omnis (symbol OMNI) are digital tokens that are necessary for the use of some features of the Omni Protocol. The total number of Omnis in existence is 619,478.6 and no more MSC will ever be created. Additionally, Omnis can not be mined into existence. The 619,478.6 OMNI were generated as a result of a public fundraiser in the style of Kickstarter.com.",
+                                "FIRST" : "Omnis (symbol OMNI) are digital tokens that are necessary for the use of some features of the Omni Protocol. The total number of Omnis in existence is 619,478.6 and no more MSC will ever be created. Additionally, Omnis can not be mined into existence. The 619,478.6 OMNI were generated as a result of a public fundraiser in the style of Kickstarter.com."
                         },
                         "INFO":"Information from the ",
                         "EDUCATION":"Master Protocol Education"

--- a/www/views/wallet/partials/addresses_list.html
+++ b/www/views/wallet/partials/addresses_list.html
@@ -25,13 +25,9 @@
 					<span class="glyphicon glyphicon-qrcode"></span>
 			    </a> 
 			</div>
-			<div class="col-xs-5 col-sm-2 text-right">
-                <span class="currency" title="{{address.getDisplayBalance(0)}}" ng-bind-html="address.getDisplayBalance(0) | bigjs: '0,0.00000000'"></span>
-                <span ng-show="address.getPendingNeg(0)<0" tooltip="This balance reflects Omni's pending transaction(s) with a total outgoing amount of {{address.getPendingNeg(0)*-1}} {{currency.name ? currency.name : currency.symbol | truncate:14}}">
-                    <a href="/about/faq" target="_new"><span class="glyphicon glyphicon-export"></span></a></span>
-                 <span ng-show="address.getPendingPos(0)>0" tooltip="Oh Boy, Someone sent you something from Omni. When it confirms this balance will be updated">
-                    <br><a href="/about/faq" target="_new"><span class="glyphicon glyphicon-import"></span></a> (+<span ng-bind-html="address.getPendingPos(0) | bigjs: '0,0.00000000'"></span> Unconfirmed)</span>
-			</div>
+
+			<div class="col-xs-5 col-sm-2 text-right"></div>
+
 			<div class="col-xs-5 col-sm-2 text-right" title="{{address.getDisplayBalance(0) * wallet.getAsset('0').price}}" ng-bind-html="address.getDisplayBalance(0) * wallet.getAsset(0).price | numeraljs: '$0,0.00':true"></div>
 			<div class="col-xs-2">
 				<div class="dropdown pull-right">

--- a/www/views/wallet/partials/addresses_list.html
+++ b/www/views/wallet/partials/addresses_list.html
@@ -14,16 +14,16 @@
 				<img ng-src="{{address.qr}}" ng-show="showqr">{{address.hash}}
 				<a href ng-click="showqr = !showqr">
 					<span class="glyphicon glyphicon-qrcode"></span>
-			    </a> 
-            	<a href="/about/faq" target="_new">
-            		<span class="glyphicon glyphicon-lock" tooltip="Your Wallet has the Private key for this address. (Click for more info)"></span>
-            	</a>
+				</a>
+				<a href="/about/faq" target="_new">
+					<span class="glyphicon glyphicon-lock" tooltip="Your Wallet has the Private key for this address. (Click for more info)"></span>
+				</a>
 			</div>
 			<div class="col-xs-12 col-sm-6" ng-if="address.privkey == undefined && address.pubkey == undefined">
 				<img ng-src="{{address.qr}}" ng-show="showqr">{{address.hash}}
 				<a href ng-click="showqr = !showqr">
 					<span class="glyphicon glyphicon-qrcode"></span>
-			    </a> 
+				</a>
 			</div>
 
 			<div class="col-xs-5 col-sm-2 text-right"></div>

--- a/www/views/wallet/partials/assets_list.html
+++ b/www/views/wallet/partials/assets_list.html
@@ -6,12 +6,12 @@
 				<div class="col-xs-12 col-sm-5" ng-if="asset.symbol=='BTC'">{{ 'COMMON.BITCOIN' | translate }}</div>
 				<div class="col-xs-6 col-sm-4 text-right">
 					<span ng-if="asset.divisible != undefined && !asset.divisible" class="currency" title="{{asset.displayBalance}}" ng-bind-html="asset.displayBalance | bigjs: '0,0'"></span>
-	                <span ng-if="asset.divisible != undefined && asset.divisible" class="currency" title="{{asset.displayBalance}}" ng-bind-html="asset.displayBalance | bigjs: '0,0.00000000'"></span>
-	                <span ng-if="asset.divisible == undefined" class="currency" title="{{asset.displayBalance}}"><span ng-bind-html="asset.displayBalance | bigjs: '0,0.00000000'"></span></span>
-		            <span ng-show="asset.displayPendingNeg<0" tooltip="This balance reflects Omni's pending transaction(s) with a total outgoing amount of {{asset.displayPendingNeg*-1}} {{asset.name ? asset.name : asset.symbol | truncate:14}}">
-	              <a href="/about/faq" target="_new"><span class="glyphicon glyphicon-export"></span></a></span>
-	            <span ng-show="asset.displayPendingPos>0" tooltip="Oh Boy, Someone sent you something. When it confirms this balance will be updated">
-	              <br><a href="/about/faq" target="_new"><span class="glyphicon glyphicon-import"></span></a> (+<span ng-bind-html="asset.displayPendingPos | bigjs: '0,0.00000000'"></span> Unconfirmed)</span>
+					<span ng-if="asset.divisible != undefined && asset.divisible" class="currency" title="{{asset.displayBalance}}" ng-bind-html="asset.displayBalance | bigjs: '0,0.00000000'"></span>
+					<span ng-if="asset.divisible == undefined" class="currency" title="{{asset.displayBalance}}"><span ng-bind-html="asset.displayBalance | bigjs: '0,0.00000000'"></span></span>
+					<span ng-show="asset.displayPendingNeg<0" tooltip="This balance reflects Omni's pending transaction(s) with a total outgoing amount of {{asset.displayPendingNeg*-1}} {{asset.name ? asset.name : asset.symbol | truncate:14}}">
+					  <a href="/about/faq" target="_new"><span class="glyphicon glyphicon-export"></span></a></span>
+					<span ng-show="asset.displayPendingPos>0" tooltip="Oh Boy, Someone sent you something. When it confirms this balance will be updated">
+					  <br><a href="/about/faq" target="_new"><span class="glyphicon glyphicon-import"></span></a> (+<span ng-bind-html="asset.displayPendingPos | bigjs: '0,0.00000000'"></span> Unconfirmed)</span>
 				</div>
 				<div class="col-xs-6 col-sm-3 text-right" title="{{asset.value}}" ng-bind-html="asset.value | numeraljs: '$0,0.00':true"></div>
 			</div>

--- a/www/views/wallet/send.html
+++ b/www/views/wallet/send.html
@@ -14,12 +14,12 @@
               <label for="chooseCoin" >{{ 'WALLET.SEND.CHOOSECOIN' | translate}}</label>
               <div class="btn-group send-asset-dropdown">
                 <button class="btn btn-clear dropdown-toggle" type="button" id="chooseCoin" data-toggle="dropdown" aria-expanded="false">
-                  {{selectedAsset.name | truncate:14}} <small class="text-muted" ng-show="selectedAsset.id > 2">({{selectedAsset.id}})</small>
+                  {{selectedAsset.name | truncate:14}} <small class="text-muted" ng-show="selectedAsset.id > 0">({{selectedAsset.id}})</small>
                   <span class="caret pull-right"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="chooseCoin">
                   <li role="presentation" ng-repeat="asset in wallet.assets" ng-if="asset.tradable && ((asset.id < 2147483648 && asset.id != 2) || showtesteco === 'true')">
-                    <a role="menuitem" tabindex="-1" href="#" ng-click="setAsset(asset)">{{asset.name | truncate:14}} <small class="text-muted" ng-show="asset.id > 2">({{asset.id}})</small></a>
+                    <a role="menuitem" tabindex="-1" href="#" ng-click="setAsset(asset)">{{asset.name | truncate:14}} <small class="text-muted" ng-show="asset.id > 0">({{asset.id}})</small></a>
                   </li>
                 </ul>
               </div>
@@ -51,7 +51,7 @@
                 <span ng-if="selectedAsset.symbol != 'BTC'">
                   {{ 'WALLET.SEND.AMOUNT' | translate}}
                 </span>
-                ({{selectedAddress.getDisplayBalance(selectedAsset.id)}} {{selectedAsset.name | truncate:14}} <small class="text-muted" ng-show="selectedAsset.id > 2">({{selectedAsset.id}})</small> {{ 'COMMON.AVAILABLE' | translate}})
+                ({{selectedAddress.getDisplayBalance(selectedAsset.id)}} {{selectedAsset.name | truncate:14}} <small class="text-muted" ng-show="selectedAsset.id > 0">({{selectedAsset.id}})</small> {{ 'COMMON.AVAILABLE' | translate}})
               </label>
               <div class="input-group" ng-show="selectedAsset.symbol == 'BTC'">
                 <span class="input-group-addon no-padding">


### PR DESCRIPTION
Fix spacing/indenting
Speed up initial wallet load by removing history transactions from wallet.addresses and making it an on demand load/call (also keeps data fresh)
Remove overall 'token' sum when displaying by address (doesn't make sense to have the total sum of different tokens. Will need to update the balance display to be accurate and not just btc value
additional bug fixes