### PR TITLE
Fix send page

### DIFF
--- a/www/views/wallet/send.html
+++ b/www/views/wallet/send.html
@@ -65,13 +65,13 @@
                 </span>
                 <input id="amount" name="amount" type="number" ng-model="sendAmount" class="form-control" value="sendAmount"
                     placeholder="{{selectedAsset.divisible ? '1.00000000' : '1'}}" step="{{selectedAsset.divisible ? 0.00000001 : 1}}" 
-                    min="{{selectedAsset.divisible ? 0.00000001 : 1}}" max="{{selectedAddress.getDisplayBalance(selectedAsset.id) - minersFee.valueOf()}}" required>
+                    min="{{selectedAsset.divisible ? 0.00000001 : 1}}" max="{{selectedAddress.getDisplayBalance(selectedAsset.id) - minersFee.valueOf()}}">
                 <div class="hint">({{sendByValue ? ((sendAmount || 0) / selectedAsset.price).toFixed(4) : ((sendAmount || 0) * selectedAsset.price).toFixed(2)}} {{sendByValue ? 'BTC' : userCurrency}})</div>
               </div>
               <input ng-show="selectedAsset.symbol != 'BTC'" id="amount" name="amount" type="number" ng-model="sendAmount" 
                     class="form-control" value="sendAmount"
                     placeholder="{{selectedAsset.divisible ? '1.00000000' : '1'}}" step="{{selectedAsset.divisible ? 0.00000001 : 1}}" 
-                    min="{{selectedAsset.divisible ? 0.00000001 : 1}}" max="{{selectedAddress.getDisplayBalance(selectedAsset.id)}}" required>
+                    min="{{selectedAsset.divisible ? 0.00000001 : 1}}" max="{{selectedAddress.getDisplayBalance(selectedAsset.id)}}">
             </div> 
             <div class="col-sm-6">
               <label class="text-justify" >{{ 'WALLET.SEND.TO' | translate}}</label>


### PR DESCRIPTION
remove required field for the duplicate 'amount' columns. Some users reported issues with sending where the send page would complain about the 'required / hidden' field.
