### PR TITLE
add email required

### DIFF
--- a/www/js/lang/en-US.js
+++ b/www/js/lang/en-US.js
@@ -161,7 +161,7 @@ angular.module("omniConfig")
 			"STRENGTH":"Strength",
 			"REPEAT":"Repeat Password",
 			"EMAIL":"Email",
-			"EMAILHOLDER":"Enter an email address (optional)"
+			"EMAILHOLDER":"Enter an email address"
 		},
 		"LOGIN":{
 			"ID":"Wallet ID",

--- a/www/locales/ar.json
+++ b/www/locales/ar.json
@@ -160,7 +160,7 @@
 			"STRENGTH":"Strength",
 			"REPEAT":"Repeat Password",
 			"EMAIL":"Email",
-			"EMAILHOLDER":"Enter an email address (optional)"
+			"EMAILHOLDER":"Enter an email address"
 		},
 		"LOGIN":{
 			"ID":"Wallet ID",

--- a/www/locales/en.json
+++ b/www/locales/en.json
@@ -160,7 +160,7 @@
 			"STRENGTH":"Strength",
 			"REPEAT":"Repeat Password",
 			"EMAIL":"Email",
-			"EMAILHOLDER":"Enter an email address (optional)"
+			"EMAILHOLDER":"Enter an email address"
 		},
 		"LOGIN":{
 			"ID":"Wallet ID",

--- a/www/locales/zh.json
+++ b/www/locales/zh.json
@@ -160,7 +160,7 @@
 			"STRENGTH":"Strength",
 			"REPEAT":"Repeat Password",
 			"EMAIL":"Email",
-			"EMAILHOLDER":"Enter an email address (optional)"
+			"EMAILHOLDER":"Enter an email address"
 		},
 		"LOGIN":{
 			"ID":"Wallet ID",

--- a/www/views/modals/partials/create_footer.html
+++ b/www/views/modals/partials/create_footer.html
@@ -2,7 +2,7 @@
   <div class="controls">
     <img ng-show="validating" src="/assets/img/spinner.gif" alt="loading">
     <button type="button" class="btn btn-tertiary" ng-disabled="loginInProgress" ng-click="dismiss('close')">{{ 'COMMON.CANCEL' | translate }}</button>
-    <input type="submit" ng-click="!createForm.$invalid && createWallet(createForm.create)" class="btn btn-main" ng-disabled="validating || createForm.$invalid || (createForm.create.password != createForm.create.repeatPassword) || ((createForm.create.password | passwordPercent).replace('%', '') < 70)" value="Create Wallet">
+    <input type="submit" ng-click="!createForm.$invalid && createWallet(createForm.create)" class="btn btn-main" ng-disabled="validating || createForm.$invalid || (createForm.create.password != createForm.create.repeatPassword) || ((createForm.create.password | passwordPercent).replace('%', '') < 70) || (createForm.create.email == null)" value="Create Wallet">
   </div>
 </div>
 <div style="color:red" ng-show="walletExists">{{ 'MODALS.CREATE.MESSAGES.UUID' | translate }}</div>


### PR DESCRIPTION
To many users having issues with lost walletids. Since we email walletid to new wallets make sure users provide an email we can send them the welcome email. 