### PR TITLE
Fix pending tx26 parsing

### DIFF
--- a/api/pending.py
+++ b/api/pending.py
@@ -88,8 +88,8 @@ def insertomni(rawtx):
       else:
         amount = int(rawtx['MP']['amountforsale'])
 
-    if txtype == 55:
-      #handle grants to ourself or others
+    if txtype in [26,55]:
+      #handle grants to ourself/others and cancel by price on OmniDex
       if receiver == "":
         sendamount=amount
         recvamount=0


### PR DESCRIPTION
tx26 cancels were incorrectly debiting user accounts when we parsed the pending tx