### PR TITLE
port api/pushtx.py to Python 3

### DIFF
--- a/api/pushtx.py
+++ b/api/pushtx.py
@@ -1,5 +1,4 @@
-import urlparse
-import os, sys,re
+import os, sys, re
 #tools_dir = os.environ.get('TOOLSDIR')
 #lib_path = os.path.abspath(tools_dir)
 #sys.path.append(lib_path)
@@ -11,83 +10,85 @@ from pending import *
 sys.path.append(os.path.abspath("../lib"))
 from stats_backend import StatsBackend
 
-error_codez= {
- '-1': 'Exception thrown. Contact a developer.',
- '-2': 'Server is in safe mode. Contact a developer.',
- '-3': 'Unexpected type. Contact a developer.',
- '-5': 'Invalid address or key. Contact a developer.',
- '-7': 'Out of memory. Contact a developer.',
- '-8': 'Invalid parameter. Contact a developer.',
- '-20': 'Database error. Contact a developer.',
- '-22': 'Error parsing transaction. Contact a developer.',
- '-25': 'General error. Contact a developer.',
- '-26': 'Transaction rejected by the network.',
- '-27': 'Transaction already in chain. Contact a developer.',
- '1': 'Transaction malformed. Contact a developer.',
- '16': 'Transaction was invalid. Contact a developer.',
- '65': 'Transaction sent was under dust limit. Contact a developer.',
- '66': 'Transaction did not meet fees. Try increasing Miner Fee.',
- '69.2': 'Your hair is on fire. Contact a stylist.'
+error_codez = {
+    '-1': 'Exception thrown. Contact a developer.',
+    '-2': 'Server is in safe mode. Contact a developer.',
+    '-3': 'Unexpected type. Contact a developer.',
+    '-5': 'Invalid address or key. Contact a developer.',
+    '-7': 'Out of memory. Contact a developer.',
+    '-8': 'Invalid parameter. Contact a developer.',
+    '-20': 'Database error. Contact a developer.',
+    '-22': 'Error parsing transaction. Contact a developer.',
+    '-25': 'General error. Contact a developer.',
+    '-26': 'Transaction rejected by the network.',
+    '-27': 'Transaction already in chain. Contact a developer.',
+    '1': 'Transaction malformed. Contact a developer.',
+    '16': 'Transaction was invalid. Contact a developer.',
+    '65': 'Transaction sent was under dust limit. Contact a developer.',
+    '66': 'Transaction did not meet fees. Try increasing Miner Fee.',
+    '69.2': 'Your hair is on fire. Contact a stylist.'
 }
 
 
 def pushtx_response(response_dict):
-    expected_fields=['signedTransaction']
+    expected_fields = ['signedTransaction']
     for field in expected_fields:
-        if not response_dict.has_key(field):
-            return (None, 'No field '+field+' in response dict '+str(response_dict))
+        if field not in response_dict:
+            return (None, 'No field ' + field + ' in response dict ' + str(response_dict))
         if len(response_dict[field]) != 1:
-            return (None, 'Multiple values for field '+field)
-            
-    signed_tx=response_dict['signedTransaction'][0]
-    
-    response=pushtxnode(signed_tx)
+            return (None, 'Multiple values for field ' + field)
+
+    signed_tx = response_dict['signedTransaction'][0]
+
+    response = pushtxnode(signed_tx)
 
     if "NOTOK" not in response:
-      try:
-        insertpending(signed_tx)
-      except Exception as e:
-        print "error inserting pending tx"+str(e)
-    
-    print signed_tx,'\n', response
+        try:
+            insertpending(signed_tx)
+        except Exception as e:
+            print("error inserting pending tx" + str(e))
+
+    print(signed_tx, '\n', response)
     return (response, None)
 
+
 def pushtxnode(signed_tx):
-    import commands, json
-    signed_tx = re.sub(r'\W+', '', signed_tx) #check alphanumeric
-    #output=commands.getoutput('bitcoind sendrawtransaction ' +  str(signed_tx) )
-    print "final signed", signed_tx
-    output=sendrawtransaction(str(signed_tx))
-    #output="Test output for error code handling: : {u'message': u'66: insufficient priority', u'code': -26}"
+    import json
+    signed_tx = re.sub(r'\W+', '', signed_tx)  # check alphanumeric
+    # output=subprocess.getoutput('bitcoind sendrawtransaction ' +  str(signed_tx) )
+    print("final signed", signed_tx)
+    output = sendrawtransaction(str(signed_tx))
+    # output="Test output for error code handling: : {u'message': u'66: insufficient priority', u'code': -26}"
 
-    print 'raw response',output,'\n'
+    print('raw response', output, '\n')
 
-    ret=re.findall('{.+',str(output))
+    ret = re.findall('{.+', str(output))
     if 'code' in ret[0]:
         try:
-          output=json.loads(ret[0])
+            output = json.loads(ret[0])
         except TypeError:
-          output=ret[0]
+            output = ret[0]
         except ValueError:
-          #reverse the single/double quotes and strip leading u in output to make it json compatible
-          output=json.loads(ret[0].replace("'",'"').replace('u"','"'))
+            # reverse the single/double quotes and strip leading u in output to make it json compatible
+            output = json.loads(ret[0].replace("'", '"').replace('u"', '"'))
 
-        response_status='NOTOK'
+        response_status = 'NOTOK'
         try:
-          message=error_codez[ output['message'].split(":")[0] ]
-        except:
-          message=output['message']
+            message = error_codez[output['message'].split(":")[0]]
+        except KeyError:
+            message = output['message']
 
         try:
-          response=json.dumps({"status":response_status, "pushed": error_codez[ str(output['code']) ], "message": message, "code": output['code'] })
-        except KeyError, e:
-          response=json.dumps({"status":response_status, "pushed": str(e), "message": message, "code": output['code'] })
+            response = json.dumps({"status": response_status, "pushed": error_codez[str(output['code'])], "message": message, "code": output['code']})
+        except KeyError as e:
+            response = json.dumps({"status": response_status, "pushed": str(e), "message": message, "code": output['code']})
     else:
-        response_status='OK'
-        response=json.dumps({"status":response_status, "pushed": 'success', "tx": output['result'] })
+        response_status = 'OK'
+        response = json.dumps({"status": response_status, "pushed": 'success', "tx": output['result']})
 
-    print response
+    print(response)
     return response
+
 
 def pushtx_handler(environ, start_response):
     return general_handler(environ, start_response, pushtx_response)


### PR DESCRIPTION
## Summary

`api/pushtx.py` still uses five Python 2 idioms that prevent the file from being imported on Python 3 (and therefore prevent the entire WSGI app from starting, since msc_apps.py imports this module transitively):

- `import urlparse` — `urlparse` was renamed to `urllib.parse` in Python 3. The import is unused in this file (the only `urlparse.` call in the whole `api/` package is in msc_apps.py, which still has its own copy of the same broken import) so it can simply be removed.
- `import commands` — `commands` was removed in Python 3 in favor of `subprocess`. The import is only there for the (commented-out) `commands.getoutput(...)` call, so it can also be removed.
- `response_dict.has_key(field)` — `has_key` was removed from dict in Python 2.3. Use `field in response_dict`.
- Three `print` statements without parentheses — `print` is a function in Python 3.
- `except KeyError, e:` — the comma form was removed in Python 3; the parser tries to evaluate `e` as an expression and raises SyntaxError.
- One bare `except:` on the error_codez lookup — narrows to `except KeyError:` so a non-dict return value or AttributeError surfaces instead of being silently masked.

This is the same Python 2 → 3 migration that earlier sessions applied to armory_service.py, pending.py, msc_apps.py, and rpcclient.py in the api package. msc_apps.py was fixed for the SyntaxError but only the offending lines were addressed; pushtx.py was not touched, and the WSGI process still refused to start because msc_apps.py imports the whole api/ package on startup.

## Testing

`python3 -c 'import ast; ast.parse(open("api/pushtx.py").read())` reports no SyntaxError. The file now parses under Python 3 and no longer references `urlparse`, `commands`, `has_key`, or the Python 2 except clause form.