### PR TITLE
port api/transaction_service.py to Python 3

### DIFF
--- a/api/transaction_service.py
+++ b/api/transaction_service.py
@@ -1,4 +1,3 @@
-import urlparse
 import os, sys, re
 import math
 from flask import Flask, request, Response, jsonify, abort, json, make_response
@@ -25,8 +24,8 @@ def estimatefees(addr):
     try:
       fees=getfeesRaw()
     except Exception as e:
-      print "Fee lookup failed, falling back"
-      print e
+      print("Fee lookup failed, falling back")
+      print(e)
       fees={"unit": "Satoshi/kB", "faster": 275000, "fast": 245000, "normal": 215000}
 
     #initial miner fee estimate
@@ -71,7 +70,7 @@ def estimatefees(addr):
          "class_c":{"faster": faster, "fast": fast, "normal": normal, "estimates":{"size":size, "ins":ins, "outs":outs} },
          "topup_c":{"faster": tfaster, "fast": tfast, "normal": tnormal, "estimates":{"size":tsize, "ins":ins+1, "outs":outs} }
         }
-    print ret
+    print(ret)
     return jsonify(ret)
 
 @app.route('/fees')
@@ -81,7 +80,7 @@ def getfees():
 def getfeesRaw():
     fee={}
     ROWS=dbSelect("select value from settings where key='feeEstimates'")
-    print ROWS
+    print(ROWS)
     if len(ROWS) > 0:
       fee=json.loads(ROWS[0][0])
 


### PR DESCRIPTION
## Summary

Same Python 2 → 3 migration that earlier sessions applied to armory_service.py, pending.py, msc_apps.py, rpcclient.py, pushtx.py, and send.py in the api package. Three changes:

1. Remove the dead `import urlparse` (the module was renamed to `urllib.parse` in Python 3, and this file never references urlparse anyway).
2. Parenthesize the four print statements on lines 28, 29, 74, 84 (Python 3 requires `print()` since the `print` statement was removed).

The bare `except:` on the `request.form[..]` parse is left alone for this commit since the surrounding logic (zero default on failure) is intentional and a separate concern from the print-statement port.

Without this fix, `import transaction_service` raises `ModuleNotFoundError: No module named 'urlparse'` on Python 3, which means the `/estimatefee/<addr>` and `/fees` endpoints registered in this file are unreachable, and (because `msc_apps.py` imports this module transitively) the entire WSGI app refuses to start.